### PR TITLE
🛠️ Dependabot PRs can't access repository secrets (Gi

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip for Dependabot PRs - they don't have access to secrets
+    if: github.actor != 'dependabot[bot]'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
Dependabot PRs can't access repository secrets (GitHub security feature), so the `CLAUDE_CODE_OAUTH_TOKEN` was empty, causing the claude-code-review workflow to fail.

### What I fixed
Edited `.github/workflows/claude-code-review.yml` to add condition `if: github.actor != 'dependabot[bot]'` to skip the Claude code review job for Dependabot PRs. This is the right fix because:
1. Dependabot PRs are security-restricted from accessing secrets by design
2. AI code review of lockfile-only dependency bumps provides minimal value
3. The actual dependency changes (glob 10.4.5 → 10.5.0) are unrelated to the CI failure

The commit `72f9a03` is ready on branch `kaylee/pr-11-fix-1767928450994`.

### The details
<details>
<summary>Full diagnosis</summary>

### Root Cause
Dependabot PRs can't access repository secrets (GitHub security feature), so the `CLAUDE_CODE_OAUTH_TOKEN` was empty, causing the claude-code-review workflow to fail.

### Fix
Edited `.github/workflows/claude-code-review.yml` to add condition `if: github.actor != 'dependabot[bot]'` to skip the Claude code review job for Dependabot PRs. This is the right fix because:
1. Dependabot PRs are security-restricted from accessing secrets by design
2. AI code review of lockfile-only dependency bumps provides minimal value
3. The actual dependency changes (glob 10.4.5 → 10.5.0) are unrelated to the CI failure

The commit `72f9a03` is ready on branch `kaylee/pr-11-fix-1767928450994`.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #11 in phrazzld/anyzine*
