### PR TITLE
🔧 `claude-code-review` workflow runs on all PRs but

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip Dependabot PRs since they can't access secrets
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
The `claude-code-review` workflow runs on all PRs but requires `CLAUDE_CODE_OAUTH_TOKEN` secret. Dependabot PRs cannot access repository secrets (GitHub security feature), causing the "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required" error.

### What I fixed
Edited `.github/workflows/claude-code-review.yml` to add condition:
```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

This skips the Claude code review job for Dependabot-authored PRs since they can't access the secrets needed for authentication. The actual Vite dependency bump in the PR is fine - it was just the review workflow that was failing.

### The details
<details>
<summary>Full diagnosis</summary>

Done!

### Root Cause
The `claude-code-review` workflow runs on all PRs but requires `CLAUDE_CODE_OAUTH_TOKEN` secret. Dependabot PRs cannot access repository secrets (GitHub security feature), causing the "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required" error.

### Fix
Edited `.github/workflows/claude-code-review.yml` to add condition:
```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

This skips the Claude code review job for Dependabot-authored PRs since they can't access the secrets needed for authentication. The actual Vite dependency bump in the PR is fine - it was just the review workflow that was failing.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #9 in phrazzld/anyzine*
